### PR TITLE
[FEAT] 챌린지 인증 로직 구현

### DIFF
--- a/src/main/java/com/BeilsangServer/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/converter/ChallengeConverter.java
@@ -14,9 +14,9 @@ public class ChallengeConverter {
 
     public static Challenge toChallenge(ChallengeRequestDTO.CreateChallengeDTO request, String mainImageUrl, String certImageUrl) {
 
-        // 시작일로부터 기간(7일/30일)만큼 지난 날짜를 챌린지 종료 날짜로 설정
+        // 시작일을 포함하여 기간(7일/30일)만큼 지난 날짜를 챌린지 종료 날짜로 설정
         Integer period = request.getPeriod().getDays();
-        LocalDate finishDate = request.getStartDate().plusDays(period);
+        LocalDate finishDate = request.getStartDate().plusDays(period - 1);
 
         return Challenge.builder()
                 .title(request.getTitle())

--- a/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
@@ -72,7 +72,15 @@ public class ChallengeService {
                 .forEach(challengeNoteRepository::save);
 
         // ChallengeMember, Challenge 저장
-        challengeMemberRepository.save(ChallengeMember.builder().challenge(challenge).member(member).isHost(true).build());
+        challengeMemberRepository.save(
+                ChallengeMember.builder()
+                        .challenge(challenge)
+                        .member(member)
+                        .isHost(true)
+                        .successDays(0)
+                        .challengeStatus(ChallengeStatus.NOT_YET)
+                        .isFeedUpload(false)
+                        .build());
         challengeRepository.save(challenge);
 
         return ChallengeConverter.toChallengePreviewDTO(challenge, member.getNickName());
@@ -258,12 +266,13 @@ public class ChallengeService {
 
         challengeMemberRepository.save(
                 ChallengeMember.builder()
-                .challenge(challenge)
-                .member(member)
-                .successDays(0)
-                .challengeStatus(ChallengeStatus.ONGOING)
-                .isHost(false)
-                .build()
+                        .challenge(challenge)
+                        .member(member)
+                        .isHost(false)
+                        .successDays(0)
+                        .challengeStatus(ChallengeStatus.NOT_YET)
+                        .isFeedUpload(false)
+                        .build()
         );
 
         // 챌린지 호스트 찾기

--- a/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
@@ -330,5 +330,4 @@ public class ChallengeService {
         Member host = challengeMemberRepository.findByChallenge_IdAndIsHostIsTrue(challengeId).getMember();
         return host.getNickName();
     }
-
 }

--- a/src/main/java/com/BeilsangServer/domain/feed/service/FeedService.java
+++ b/src/main/java/com/BeilsangServer/domain/feed/service/FeedService.java
@@ -63,12 +63,12 @@ public class FeedService {
     public Long createFeed(AddFeedRequestDTO.CreateFeedDTO request, Long challengeId, Long memberId){
 
         Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(() -> {throw new IllegalArgumentException("없는챌린지다.");});
-        ChallengeMember challengeMember = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId,challenge.getId());
+        ChallengeMember challengeMember = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challenge.getId());
 
         Uuid feedUuid = uuidRepository.save(Uuid.builder().uuid(UUID.randomUUID().toString()).build());
         String feedUrl = s3Manager.uploadFile(s3Manager.generateFeedKeyName(feedUuid), request.getFeedImage());
 
-        Feed feed = feedConverter.toEntity(request,challenge,challengeMember,feedUrl);
+        Feed feed = feedConverter.toEntity(request, challenge, challengeMember, feedUrl);
 
         feedRepository.save(feed);
 

--- a/src/main/java/com/BeilsangServer/domain/feed/service/FeedService.java
+++ b/src/main/java/com/BeilsangServer/domain/feed/service/FeedService.java
@@ -19,6 +19,7 @@ import com.BeilsangServer.domain.member.entity.ChallengeMember;
 import com.BeilsangServer.domain.member.entity.Member;
 import com.BeilsangServer.domain.member.repository.ChallengeMemberRepository;
 import com.BeilsangServer.domain.member.repository.MemberRepository;
+import com.BeilsangServer.domain.member.service.ChallengeMemberService;
 import com.BeilsangServer.domain.uuid.entity.Uuid;
 import com.BeilsangServer.domain.uuid.repository.UuidRepository;
 import com.BeilsangServer.global.enums.Category;
@@ -48,6 +49,7 @@ public class FeedService {
     private final ChallengeNoteRepository challengeNoteRepository;
     private final UuidRepository uuidRepository;
     private final MemberRepository memberRepository;
+    private final ChallengeMemberService challengeMemberService;
 
 
     /***
@@ -69,6 +71,8 @@ public class FeedService {
         Feed feed = feedConverter.toEntity(request,challenge,challengeMember,feedUrl);
 
         feedRepository.save(feed);
+
+        challengeMemberService.checkFeedUpload(feed.getChallengeMember());
 
         return feed.getId();
     }

--- a/src/main/java/com/BeilsangServer/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/com/BeilsangServer/domain/member/entity/ChallengeMember.java
@@ -24,6 +24,7 @@ public class ChallengeMember extends BaseEntity {
 
     private Integer successDays;
 
+    @Enumerated(EnumType.STRING)
     private ChallengeStatus challengeStatus;
 
     private Boolean isFeedUpload;
@@ -39,6 +40,10 @@ public class ChallengeMember extends BaseEntity {
     // 피드 업로드 상태 수정
     public void makeIsFeedUploadFalse() {
         this.isFeedUpload = false;
+    }
+
+    public void makeIsFeedUploadTrue() {
+        this.isFeedUpload = true;
     }
 
     // 챌린지 상태 변경 메서드

--- a/src/main/java/com/BeilsangServer/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/com/BeilsangServer/domain/member/entity/ChallengeMember.java
@@ -26,6 +26,8 @@ public class ChallengeMember extends BaseEntity {
 
     private ChallengeStatus challengeStatus;
 
+    private Boolean isFeedUpload;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -34,4 +36,8 @@ public class ChallengeMember extends BaseEntity {
     @JoinColumn(name = "challenge_id")
     private Challenge challenge;
 
+    // 피드 업로드 상태 수정
+    public void makeIsFeedUploadFalse() {
+        this.isFeedUpload = false;
+    }
 }

--- a/src/main/java/com/BeilsangServer/domain/member/entity/ChallengeMember.java
+++ b/src/main/java/com/BeilsangServer/domain/member/entity/ChallengeMember.java
@@ -40,4 +40,14 @@ public class ChallengeMember extends BaseEntity {
     public void makeIsFeedUploadFalse() {
         this.isFeedUpload = false;
     }
+
+    // 챌린지 상태 변경 메서드
+    public void updateChallengeStatus(ChallengeStatus status) {
+        this.challengeStatus = status;
+    }
+
+    // 성공 일수 증가 메서드
+    public void increaseSuccessDays() {
+        this.successDays++;
+    }
 }

--- a/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
@@ -19,7 +19,7 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
 
     Long countByMember_Id(Long memberId);
 
-    List<ChallengeMember> findAllByIsFeedUpload(Boolean isFeedUpload);
-
     List<ChallengeMember> findAllByChallengeStatus(ChallengeStatus challengeStatus);
+
+    List<ChallengeMember> findAllByChallengeStatusAndIsFeedUpload(ChallengeStatus challengeStatus, Boolean isFeedUpload);
 }

--- a/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
@@ -18,4 +18,5 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
 
     Long countByMember_Id(Long memberId);
 
+    List<ChallengeMember> findAllByIsFeedUpload(Boolean isFeedUpload);
 }

--- a/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
@@ -2,6 +2,7 @@ package com.BeilsangServer.domain.member.repository;
 
 import com.BeilsangServer.domain.challenge.entity.Challenge;
 import com.BeilsangServer.domain.member.entity.ChallengeMember;
+import com.BeilsangServer.global.enums.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -19,4 +20,6 @@ public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember
     Long countByMember_Id(Long memberId);
 
     List<ChallengeMember> findAllByIsFeedUpload(Boolean isFeedUpload);
+
+    List<ChallengeMember> findAllByChallengeStatus(ChallengeStatus challengeStatus);
 }

--- a/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
@@ -24,7 +24,7 @@ public class ChallengeMemberService {
      * 하루동안 인증하지 않은 챌린지 멤버의 상태 수정
      * 스케줄러를 사용하여 피드가 올라가 있지 않은 챌린지 멤버의 상태 변경
      */
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "19 45 0 * * *")
     @Transactional
     public void checkFailure() {
 
@@ -80,5 +80,17 @@ public class ChallengeMemberService {
                     challengeMember.updateChallengeStatus(ChallengeStatus.ONGOING);
                     challengeMemberRepository.save(challengeMember);
                 });
+    }
+
+    // 피드 등록 시 당일 성공 처리
+    @Transactional
+    public void checkFeedUpload(ChallengeMember challengeMember) {
+
+        // 처음 피드가 올라가는 경우에만 isFeedUpload, successDays 수정
+        if (!challengeMember.getIsFeedUpload()) {
+            challengeMember.makeIsFeedUploadTrue();
+            challengeMember.increaseSuccessDays();
+            challengeMemberRepository.save(challengeMember);
+        }
     }
 }

--- a/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
@@ -1,0 +1,27 @@
+package com.BeilsangServer.domain.member.service;
+
+import com.BeilsangServer.domain.member.repository.ChallengeMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeMemberService {
+
+    private final ChallengeMemberRepository challengeMemberRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void dailyMakeIsFeedUploadFalse() {
+
+        // 매일 정시마다 모든 챌린지 멤버의 인증 상태 수정
+        challengeMemberRepository.findAll().forEach(challengeMember -> {
+            challengeMember.makeIsFeedUploadFalse();
+            challengeMemberRepository.save(challengeMember);
+        });
+    }
+
+}

--- a/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
@@ -1,7 +1,6 @@
 package com.BeilsangServer.domain.member.service;
 
 import com.BeilsangServer.domain.challenge.entity.Challenge;
-import com.BeilsangServer.domain.challenge.repository.ChallengeRepository;
 import com.BeilsangServer.domain.member.entity.ChallengeMember;
 import com.BeilsangServer.domain.member.repository.ChallengeMemberRepository;
 import com.BeilsangServer.global.enums.ChallengeStatus;
@@ -24,7 +23,7 @@ public class ChallengeMemberService {
      * 하루동안 인증하지 않은 챌린지 멤버의 상태 수정
      * 스케줄러를 사용하여 피드가 올라가 있지 않은 챌린지 멤버의 상태 변경
      */
-    @Scheduled(cron = "19 45 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void checkFailure() {
 
@@ -37,13 +36,13 @@ public class ChallengeMemberService {
             // 지금까지 성공한 일수
             int remainSuccess = challenge.getTotalGoalDay() - challengeMember.getSuccessDays();
             // 챌린지 종료일까지 남은 일수
-            int remainDay = challenge.getFinishDate().until(LocalDate.now()).getDays() + 1;
+            int remainDay = LocalDate.now().until(challenge.getFinishDate()).getDays() + 1;
 
             // 남은 일수 확인 후 목표 일수를 다 채우면 성공, 남은 기간 내에 다 채우지 못하면 실패로 변경
             if (remainSuccess == 0) {
                 challengeMember.updateChallengeStatus(ChallengeStatus.SUCCESS);
                 challengeMemberRepository.save(challengeMember);
-            } else if (remainDay > remainSuccess) {
+            } else if (remainSuccess > remainDay) {
                 challengeMember.updateChallengeStatus(ChallengeStatus.FAIL);
                 challengeMemberRepository.save(challengeMember);
             }
@@ -82,7 +81,10 @@ public class ChallengeMemberService {
                 });
     }
 
-    // 피드 등록 시 당일 성공 처리
+    /***
+     * 피드 생성 시 챌린지 인증 처리
+     * @param challengeMember 피드를 생성한 주체
+     */
     @Transactional
     public void checkFeedUpload(ChallengeMember challengeMember) {
 

--- a/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/ChallengeMemberService.java
@@ -1,10 +1,17 @@
 package com.BeilsangServer.domain.member.service;
 
+import com.BeilsangServer.domain.challenge.entity.Challenge;
+import com.BeilsangServer.domain.challenge.repository.ChallengeRepository;
+import com.BeilsangServer.domain.member.entity.ChallengeMember;
 import com.BeilsangServer.domain.member.repository.ChallengeMemberRepository;
+import com.BeilsangServer.global.enums.ChallengeStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -12,8 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChallengeMemberService {
 
     private final ChallengeMemberRepository challengeMemberRepository;
+    private final ChallengeRepository challengeRepository;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    /***
+     * 모든 챌린지 멤버의 당일 인증 상태 수정
+     * 아직 끝나지 않은 챌린지만 대상이 되어야 함
+     */
     @Transactional
     public void dailyMakeIsFeedUploadFalse() {
 
@@ -24,4 +35,39 @@ public class ChallengeMemberService {
         });
     }
 
+    /***
+     * 하루동안 인증하지 않은 챌린지 멤버의 상태 수정
+     * 스케줄러를 사용하여 피드가 올라가 있지 않은 챌린지 멤버의 상태 변경
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void checkFailure() {
+
+        List<ChallengeMember> notUploadedMember = challengeMemberRepository.findAllByIsFeedUpload(false);
+
+        for (ChallengeMember challengeMember : notUploadedMember) {
+
+            // 챌린지가 성공이나 실패로 종료로 끝난건 확인X
+            if (challengeMember.getChallengeStatus() != ChallengeStatus.ONGOING) {
+                break;
+            }
+
+            Challenge challenge = challengeMember.getChallenge();
+            // 지금까지 성공한 일수
+            int remainSuccess = challenge.getTotalGoalDay() - challengeMember.getSuccessDays();
+            // 챌린지 종료일까지 남은 일수
+            int remainDay = challenge.getFinishDate().until(LocalDate.now()).getDays() + 1;
+
+            // 남은 일수 확인 후 목표 일수를 다 채우면 성공, 남은 기간 내에 다 채우지 못하면 실패로 변경
+            if (remainSuccess == 0) {
+                challengeMember.updateChallengeStatus(ChallengeStatus.SUCCESS);
+                challengeMemberRepository.save(challengeMember);
+            } else if (remainDay > remainSuccess) {
+                challengeMember.updateChallengeStatus(ChallengeStatus.FAIL);
+                challengeMemberRepository.save(challengeMember);
+            }
+        }
+
+        dailyMakeIsFeedUploadFalse();
+    }
 }

--- a/src/main/java/com/BeilsangServer/global/enums/ChallengeStatus.java
+++ b/src/main/java/com/BeilsangServer/global/enums/ChallengeStatus.java
@@ -2,5 +2,5 @@ package com.BeilsangServer.global.enums;
 
 public enum ChallengeStatus {
 
-    SUCCESS, FAIL, ONGOING
+    SUCCESS, FAIL, ONGOING, NOT_YET
 }


### PR DESCRIPTION
1. ChallengeMember에 ChallengeStatus, isFeedUpload 컬럼을 추가함.
2. ChallengeMemberService에 스케줄러를 활용한 메서드들을 추가함.
- 하루동안 피드를 올리지 않은 첼린지멤버를 수정하는 기능 구현
- 모두 변경한 후 진행 중인 챌린지의 상태를 수정하는 기능 구현
- 그 후 새로 시작하는 챌린지의 상태를 변경하는 기능 구현
3. 피드 생성 시 인증이 되도록하는 기능을 FeedService와 ChallengeMemberService에 구현
4. 챌린지 생성 시 시작일을 포함하여 종료일을 설정하도록 수정함.