### PR TITLE
[FEAT] 멤버의 챌린지 참여 조회 API

### DIFF
--- a/src/main/java/com/BeilsangServer/domain/challenge/controller/ChallengeRestController.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/controller/ChallengeRestController.java
@@ -49,7 +49,7 @@ public class ChallengeRestController {
         //Long memberId = SecurityUtil.getCurrentUserId();
         Long memberId = 1L;
 
-        ChallengeResponseDTO.ChallengeDTO response = challengeService.getChallenge(challengeId,memberId);
+        ChallengeResponseDTO.ChallengeDTO response = challengeService.getChallenge(challengeId, memberId);
 
         return ApiResponse.onSuccess(response);
     }
@@ -107,7 +107,7 @@ public class ChallengeRestController {
     ) {
         //Long memberId = SecurityUtil.getCurrentUserId();
         Long memberId = 1L;
-        ChallengeResponseDTO.ChallengePreviewListDTO response = challengeService.getLikesList(memberId,category);
+        ChallengeResponseDTO.ChallengePreviewListDTO response = challengeService.getLikesList(memberId, category);
 
         return ApiResponse.onSuccess(response);
     }
@@ -161,11 +161,11 @@ public class ChallengeRestController {
     @PostMapping("/{challengeId}/likes")
     public ApiResponse<Long> challengeLike(
             @PathVariable(name = "challengeId") Long challengeId
-    ){
+    ) {
         //Long memberId = SecurityUtil.getCurrentUserId();
         Long memberId = 1L;
 
-        Long challengeLikeId = challengeService.challengeLike(challengeId,memberId);
+        Long challengeLikeId = challengeService.challengeLike(challengeId, memberId);
 
         return ApiResponse.onSuccess(challengeLikeId);
     }
@@ -173,10 +173,10 @@ public class ChallengeRestController {
     @DeleteMapping("/{challengeId}/likes")
     public ApiResponse<Long> challengeUnLike(
             @PathVariable(name = "challengeId") Long challengeId
-    ){
+    ) {
         //Long memberId = SecurityUtil.getCurrentUserId();
         Long memberId = 1L;
-        Long challengeUnLikeId = challengeService.challengeUnLike(challengeId,memberId);
+        Long challengeUnLikeId = challengeService.challengeUnLike(challengeId, memberId);
 
         return ApiResponse.onSuccess(challengeUnLikeId);
     }

--- a/src/main/java/com/BeilsangServer/domain/challenge/dto/ChallengeResponseDTO.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/dto/ChallengeResponseDTO.java
@@ -131,5 +131,4 @@ public class ChallengeResponseDTO {
         private ChallengePreviewDTO challengePreviewDTO;
         private MemberResponseDTO.MemberDTO memberDTO;
     }
-
 }

--- a/src/main/java/com/BeilsangServer/domain/feed/service/FeedService.java
+++ b/src/main/java/com/BeilsangServer/domain/feed/service/FeedService.java
@@ -61,7 +61,7 @@ public class FeedService {
     public Long createFeed(AddFeedRequestDTO.CreateFeedDTO request, Long challengeId, Long memberId){
 
         Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(() -> {throw new IllegalArgumentException("없는챌린지다.");});
-        ChallengeMember challengeMember = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challenge.getId());
+        ChallengeMember challengeMember = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challenge.getId()).get();
 
         Uuid feedUuid = uuidRepository.save(Uuid.builder().uuid(UUID.randomUUID().toString()).build());
         String feedUrl = s3Manager.uploadFile(s3Manager.generateFeedKeyName(feedUuid), request.getFeedImage());

--- a/src/main/java/com/BeilsangServer/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/BeilsangServer/domain/member/controller/MemberRestController.java
@@ -5,7 +5,6 @@ import com.BeilsangServer.domain.member.dto.MemberUpdateDto;
 import com.BeilsangServer.domain.member.service.MemberService;
 import com.BeilsangServer.domain.point.dto.PointResponseDTO;
 import com.BeilsangServer.global.common.apiPayload.ApiResponse;
-import com.BeilsangServer.global.common.apiPayload.ApiResponseStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,5 +68,16 @@ public class MemberRestController {
 
         boolean isExists = memberService.checkNickName(name);
         return ApiResponse.onSuccess(isExists);
+    }
+
+    @GetMapping("/check/{challengeId}")
+    public ApiResponse<MemberResponseDTO.CheckEnrolledDTO> checkIsMemberEnrolled(@PathVariable(name = "challengeId") Long challengeId) {
+
+        //Long memberId = SecurityUtil.getCurrentUserId();
+        Long memberId = 1L;
+
+        MemberResponseDTO.CheckEnrolledDTO response = memberService.checkEnroll(memberId, challengeId);
+
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/BeilsangServer/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/BeilsangServer/domain/member/controller/MemberRestController.java
@@ -6,6 +6,7 @@ import com.BeilsangServer.domain.member.service.MemberService;
 import com.BeilsangServer.domain.point.dto.PointResponseDTO;
 import com.BeilsangServer.global.common.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -71,6 +72,14 @@ public class MemberRestController {
     }
 
     @GetMapping("/check/{challengeId}")
+    @Operation(
+            summary = "멤버의 챌린지 참여 조회 API",
+            description = "챌린지ID를 PathVariable로 입력 받아 해당하는 챌린지에 멤버가 참여 중인지와, 멤버가 참여하고 있는 챌린지의 ID들을 알아내는 API입니다."
+    )
+    @Parameter(name = "challengeId", description = "챌린지 ID")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+    })
     public ApiResponse<MemberResponseDTO.CheckEnrolledDTO> checkIsMemberEnrolled(@PathVariable(name = "challengeId") Long challengeId) {
 
         //Long memberId = SecurityUtil.getCurrentUserId();

--- a/src/main/java/com/BeilsangServer/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/BeilsangServer/domain/member/converter/MemberConverter.java
@@ -3,6 +3,8 @@ package com.BeilsangServer.domain.member.converter;
 import com.BeilsangServer.domain.member.dto.MemberResponseDTO;
 import com.BeilsangServer.domain.member.entity.Member;
 
+import java.util.List;
+
 public class MemberConverter {
 
     public static MemberResponseDTO.MemberDTO toMemberDTO(Member member) {
@@ -22,5 +24,9 @@ public class MemberConverter {
                 .gender(member.getGender())
                 .address(member.getAddress())
                 .build();
+    }
+
+    public static MemberResponseDTO.CheckEnrolledDTO toCheckEnrolledDTO(Boolean isEnrolled, List<Long> enrolledChallengeIds) {
+        return MemberResponseDTO.CheckEnrolledDTO.builder().isEnrolled(isEnrolled).enrolledChallengeIds(enrolledChallengeIds).build();
     }
 }

--- a/src/main/java/com/BeilsangServer/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/BeilsangServer/domain/member/dto/MemberResponseDTO.java
@@ -1,5 +1,6 @@
 package com.BeilsangServer.domain.member.dto;
 
+import com.BeilsangServer.domain.challenge.dto.ChallengeResponseDTO;
 import com.BeilsangServer.domain.feed.dto.FeedDTO;
 import com.BeilsangServer.global.enums.Gender;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class MemberResponseDTO {
 
@@ -47,5 +49,15 @@ public class MemberResponseDTO {
         private LocalDate birth;
         private Gender gender;
         private String address;
+    }
+
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CheckEnrolledDTO {
+        private Boolean isEnrolled;
+        private List<Long> enrolledChallengeIds;
     }
 }

--- a/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
+++ b/src/main/java/com/BeilsangServer/domain/member/repository/ChallengeMemberRepository.java
@@ -7,12 +7,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long> {
 
     List<ChallengeMember> findAllByMember_id(Long memberId);
-    ChallengeMember findByMember_idAndChallenge_Id(Long memberId,Long challengeId);
+    Optional<ChallengeMember> findByMember_idAndChallenge_Id(Long memberId, Long challengeId);
 
     // 챌린지의 호스트 찾기
     ChallengeMember findByChallenge_IdAndIsHostIsTrue(Long challengeId);

--- a/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
@@ -23,9 +23,11 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -146,5 +148,17 @@ public class MemberService {
         else{
             return true;
         }
+    }
+
+    public MemberResponseDTO.CheckEnrolledDTO checkEnroll(Long memberId, Long challengeId) {
+
+        Boolean isEnrolled = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challengeId).isEmpty();
+
+        List<Long> enrolledChallengeIds = challengeMemberRepository.findAllByMember_id(memberId).stream()
+                .filter(challengeMember -> challengeMember.getChallenge().getFinishDate().isAfter(LocalDate.now()))
+                .map(challengeMember -> challengeMember.getChallenge().getId())
+                .toList();
+
+        return MemberConverter.toCheckEnrolledDTO(isEnrolled, enrolledChallengeIds);
     }
 }

--- a/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
@@ -150,6 +150,12 @@ public class MemberService {
         }
     }
 
+    /***
+     * 멤버의 챌린지 참여 여부 판단
+     * @param memberId 멤버
+     * @param challengeId 챌린지
+     * @return CheckEnrolledDTO 멤버가 해당 챌린지에 참여 중인지와, 참여 중인 챌린지의 id 값들을 보내준다
+     */
     public MemberResponseDTO.CheckEnrolledDTO checkEnroll(Long memberId, Long challengeId) {
 
         Boolean isEnrolled = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challengeId).isPresent();

--- a/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
@@ -152,7 +152,7 @@ public class MemberService {
 
     public MemberResponseDTO.CheckEnrolledDTO checkEnroll(Long memberId, Long challengeId) {
 
-        Boolean isEnrolled = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challengeId).isEmpty();
+        Boolean isEnrolled = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challengeId).isPresent();
 
         List<Long> enrolledChallengeIds = challengeMemberRepository.findAllByMember_id(memberId).stream()
                 .filter(challengeMember -> challengeMember.getChallenge().getFinishDate().isAfter(LocalDate.now()))


### PR DESCRIPTION
멤버의 챌린지 참여를 조회하는 API를 구현했습니다.
원래 로직은 프론트에서 이미 챌린지에 참여한 회원은 참여하기 버튼이 보이지 않아야 하지만, 현재 디비에 ChallengeMember 엔티티 중 challengeId와 memberId가 같은 데이터가 존재합니다.
해당 서비스는 아래의 JPA 메서드를 사용합니다. 
`Boolean isEnrolled = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challengeId).isPresent();`
**따라서 challengeId와 memberId가 같은 데이터가 여러개일 경우 Query 오류를 발생시킵니다.**
우선은 테스트 시 **같은 데이터가 없도록 디비에서 직접 처리**를 하거나, 프론트에서 처리를 해줘야 할 거 같습니다. 
후에 같은 데이터가 안들어가도록 Spring에서 예외 처리를 하겠습니다. 