### PR TITLE
[REFAC] 멤버의 챌린지 참여 조회 API 예외 상황 수정

### DIFF
--- a/src/main/java/com/BeilsangServer/BeilsangServerApplication.java
+++ b/src/main/java/com/BeilsangServer/BeilsangServerApplication.java
@@ -12,7 +12,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableFeignClients
 @EnableJpaAuditing
-@OpenAPIDefinition(servers = {@Server(url = "https://beilsang.com", description = "비일상 서버")})
+//@OpenAPIDefinition(servers = {@Server(url = "https://beilsang.com", description = "비일상 서버")})
 public class BeilsangServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
@@ -19,6 +19,8 @@ import com.BeilsangServer.domain.point.converter.PointConverter;
 import com.BeilsangServer.domain.point.dto.PointResponseDTO;
 import com.BeilsangServer.domain.point.entity.PointLog;
 import com.BeilsangServer.domain.point.repository.PointLogRepository;
+import com.BeilsangServer.global.common.apiPayload.code.status.ErrorStatus;
+import com.BeilsangServer.global.common.exception.handler.ErrorHandler;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -162,6 +164,9 @@ public class MemberService {
                 .filter(challengeMember -> challengeMember.getChallenge().getFinishDate().isAfter(LocalDate.now()))
                 .map(challengeMember -> challengeMember.getChallenge().getId())
                 .toList();
+
+//        boolean hasDuplicates = enrolledChallengeIds.stream().distinct().count() != enrolledChallengeIds.size();
+//        if (hasDuplicates) throw new ErrorHandler(ErrorStatus.HAS_DUPLICATE_CHALLENGE);
 
         Boolean isEnrolled = enrolledChallengeIds.contains(challengeId);
 

--- a/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
@@ -158,12 +158,12 @@ public class MemberService {
      */
     public MemberResponseDTO.CheckEnrolledDTO checkEnroll(Long memberId, Long challengeId) {
 
-        Boolean isEnrolled = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challengeId).isPresent();
-
         List<Long> enrolledChallengeIds = challengeMemberRepository.findAllByMember_id(memberId).stream()
                 .filter(challengeMember -> challengeMember.getChallenge().getFinishDate().isAfter(LocalDate.now()))
                 .map(challengeMember -> challengeMember.getChallenge().getId())
                 .toList();
+
+        Boolean isEnrolled = enrolledChallengeIds.contains(challengeId);
 
         return MemberConverter.toCheckEnrolledDTO(isEnrolled, enrolledChallengeIds);
     }

--- a/src/main/java/com/BeilsangServer/global/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/BeilsangServer/global/common/apiPayload/code/status/ErrorStatus.java
@@ -18,10 +18,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     // 멤버 관련 응답
+    HAS_DUPLICATE_CHALLENGE(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER5001", "같은 챌린지에 중복 참여되어 있습니다."),
 
     // 챌린지 관련 응답
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND,"CHALLENGE4001", "챌린지가 없습니다."),
-    POINT_LACK(HttpStatus.INTERNAL_SERVER_ERROR, "CHALLENGE5001", "포인트가 부족합니다.");
+    POINT_LACK(HttpStatus.INTERNAL_SERVER_ERROR, "CHALLENGE5001", "포인트가 부족합니다."),
+    ;
 
     // 피드 관련 응답
 


### PR DESCRIPTION
멤버가 같은 챌린지에 들어가 있는 경우 쿼리 에러가 나던 것을 고침.
위와 같은 상황에서 예외 처리를 해주었으나 현재 원활한 테스트를 위해 비활성화 해둠.