### PR TITLE
[REFAC] 추천 챌린지 키워드 사용 추가

### DIFF
--- a/src/main/java/com/BeilsangServer/domain/challenge/controller/ChallengeRestController.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/controller/ChallengeRestController.java
@@ -152,7 +152,10 @@ public class ChallengeRestController {
     @GetMapping("/recommends")
     public ApiResponse<ChallengeResponseDTO.RecommendChallengeListDTO> getRecommendChallenges() {
 
-        List<ChallengeResponseDTO.RecommendChallengeDTO> recommendChallengeList = challengeService.getRecommendChallenges();
+        //Long memberId = SecurityUtil.getCurrentUserId();
+        Long memberId = 1L;
+
+        List<ChallengeResponseDTO.RecommendChallengeDTO> recommendChallengeList = challengeService.getRecommendChallenges(memberId);
         ChallengeResponseDTO.RecommendChallengeListDTO response = ChallengeConverter.toRecommendChallengeListDTO(recommendChallengeList);
 
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/BeilsangServer/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/repository/ChallengeRepository.java
@@ -15,6 +15,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
     // 아직 안시작한 챌린지 중 좋아요 상위 2개 찾음
     List<Challenge> findTop2ByStartDateAfterOrderByCountLikesDesc(LocalDate localDate);
+    List<Challenge> findAllByStartDateAfterOrderByCountLikesDesc(LocalDate localDate);
 
     // 카테고리에 해당하는 모든 챌린지 리스트 형태로 반환
     List<Challenge> findAllByStartDateAfterAndCategoryOrderByAttendeeCountDesc(LocalDate localDate, Category category);

--- a/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
@@ -135,7 +135,8 @@ public class ChallengeService {
 
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Category keyword = Category.from(member.getKeyword());
+//        Category keyword = Category.from(member.getKeyword());
+        Category keyword = member.getKeyword();
 
         // 이미 참여한 챌린지는 추천하지 않도록 추가 구현
 //        List<Long> enrolledChallengeIds = challengeMemberRepository.findAllByMember_id(memberId).stream()

--- a/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
@@ -129,11 +129,32 @@ public class ChallengeService {
     /***
      * 추천 챌린지 미리보기 조회하기
      * @return ChallengeResponseDTO.RecommendChallengeDTO 2개를 리스트로 반환
+     * 이미 참여한 챌린지는 추천하지 않도록 추가 구현 필요
      */
-    public List<ChallengeResponseDTO.RecommendChallengeDTO> getRecommendChallenges() {
+    public List<ChallengeResponseDTO.RecommendChallengeDTO> getRecommendChallenges(Long memberId) {
 
-        // JPA를 사용해 아직 시작 안한 챌린지 중 좋아요 많은 2개를 리스트로 만들어 반환
-        List<Challenge> recommendChallenges = challengeRepository.findTop2ByStartDateAfterOrderByCountLikesDesc(LocalDate.now());
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Category keyword = Category.from(member.getKeyword());
+
+        // 이미 참여한 챌린지는 추천하지 않도록 추가 구현
+//        List<Long> enrolledChallengeIds = challengeMemberRepository.findAllByMember_id(memberId).stream()
+//                .filter(challengeMember -> challengeMember.getChallenge().getFinishDate().isAfter(LocalDate.now())) // 아직 끝나지 않은 챌린지만
+//                .map(challengeMember -> challengeMember.getChallenge().getId())
+//                .toList();
+//        List<Challenge> recommendChallenges = challengeRepository.findAllByStartDateAfterOrderByCountLikesDesc(LocalDate.now());
+//        List<Challenge> challenges = recommendChallenges
+//                .stream().filter(challenge -> keyword.equals(challenge.getCategory()) && !enrolledChallengeIds.contains(challenge.getId()))
+//                .limit(2)
+//                .toList();
+
+        int recommendNum = 2;
+        List<Challenge> recommendChallenges = challengeRepository.findAllByStartDateAfterOrderByCountLikesDesc(LocalDate.now())
+                .stream().filter(challenge -> keyword.equals(challenge.getCategory()))
+                .limit(recommendNum)
+                .toList();
+
+        if (recommendChallenges.size() < recommendNum) throw new ErrorHandler(ErrorStatus.CHALLENGE_INSUFFICIENT);
 
         return recommendChallenges.stream()
                 .map(challenge -> ChallengeResponseDTO.RecommendChallengeDTO.builder()

--- a/src/main/java/com/BeilsangServer/domain/member/entity/Member.java
+++ b/src/main/java/com/BeilsangServer/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.BeilsangServer.domain.member.entity;
 import com.BeilsangServer.domain.member.dto.MemberLoginDto;
 import com.BeilsangServer.domain.member.dto.MemberUpdateDto;
 import com.BeilsangServer.global.common.BaseEntity;
+import com.BeilsangServer.global.enums.Category;
 import com.BeilsangServer.global.enums.Gender;
 import com.BeilsangServer.global.enums.Provider;
 import com.BeilsangServer.global.enums.Role;
@@ -41,7 +42,10 @@ public class Member extends BaseEntity {
 
     private String address;
 
-    private String keyword;
+//    private String keyword;
+
+    @Enumerated(EnumType.STRING)
+    private Category keyword;
 
     private String discoveredPath;
 
@@ -68,7 +72,7 @@ public class Member extends BaseEntity {
         this.gender = memberLoginDto.getGender();
         this.nickName = memberLoginDto.getNickName();
         this.birth = LocalDate.parse(memberLoginDto.getBirth());
-        this.keyword = memberLoginDto.getKeyword();
+        this.keyword = Category.from(memberLoginDto.getKeyword());
         this.resolution = memberLoginDto.getResolution();
     }
 

--- a/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
+++ b/src/main/java/com/BeilsangServer/domain/member/service/MemberService.java
@@ -161,7 +161,7 @@ public class MemberService {
     public MemberResponseDTO.CheckEnrolledDTO checkEnroll(Long memberId, Long challengeId) {
 
         List<Long> enrolledChallengeIds = challengeMemberRepository.findAllByMember_id(memberId).stream()
-                .filter(challengeMember -> challengeMember.getChallenge().getFinishDate().isAfter(LocalDate.now()))
+                .filter(challengeMember -> challengeMember.getChallenge().getFinishDate().isAfter(LocalDate.now())) // 아직 끝나지 않은 챌린지만
                 .map(challengeMember -> challengeMember.getChallenge().getId())
                 .toList();
 

--- a/src/main/java/com/BeilsangServer/global/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/BeilsangServer/global/common/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND,"CHALLENGE4001", "챌린지가 없습니다."),
     CHALLENGE_HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE4002", "챌린지의 호스트가 없습니다."),
     POINT_LACK(HttpStatus.INTERNAL_SERVER_ERROR, "CHALLENGE5001", "포인트가 부족합니다."),
+    CHALLENGE_INSUFFICIENT(HttpStatus.INTERNAL_SERVER_ERROR, "CHALLENGE5002", "챌린지가 부족합니다."),
 
 
     // 피드 관련 응답


### PR DESCRIPTION
memberId를 파라미터로 키워드에 해당하는 종류의 챌린지를 추천하도록 수정하였습니다.
이때 멤버 엔티티의 키워드가 String임을 확인하여 Category형으로 수정했습니다. 

또한 추천 서비스는 카테고리에 해당하는 챌린지가 2개 미만일 경우 에러를 발생시킵니다.

후에 추가해야 하는 기능들이 있습니다.
- 부족한 챌린지는 다른 카테고리의 챌린지를 추가하여 반환
- 멤버가 이미 참여한 챌린지는 제회