### PR TITLE
Bug/283 챌린지 세부조회 시 달성율 조회 로직 

### DIFF
--- a/src/main/java/com/BeilsangServer/BeilsangServerApplication.java
+++ b/src/main/java/com/BeilsangServer/BeilsangServerApplication.java
@@ -12,7 +12,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableFeignClients
 @EnableJpaAuditing
-//@OpenAPIDefinition(servers = {@Server(url = "https://beilsang.com", description = "비일상 서버")})
+@OpenAPIDefinition(servers = {@Server(url = "https://beilsang.com", description = "비일상 서버")})
 public class BeilsangServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BeilsangServerApplication.class, args);

--- a/src/main/java/com/BeilsangServer/BeilsangServerApplication.java
+++ b/src/main/java/com/BeilsangServer/BeilsangServerApplication.java
@@ -12,7 +12,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableFeignClients
 @EnableJpaAuditing
-@OpenAPIDefinition(servers = {@Server(url = "https://beilsang.com", description = "비일상 서버")})
+//@OpenAPIDefinition(servers = {@Server(url = "https://beilsang.com", description = "비일상 서버")})
 public class BeilsangServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BeilsangServerApplication.class, args);

--- a/src/main/java/com/BeilsangServer/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/converter/ChallengeConverter.java
@@ -9,6 +9,7 @@ import com.BeilsangServer.domain.member.entity.Member;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public class ChallengeConverter {
 
@@ -35,11 +36,11 @@ public class ChallengeConverter {
                 .build();
     }
 
-    public static ChallengeResponseDTO.ChallengeDTO toChallengeDTO(Challenge challenge, Integer dDay, String hostName,boolean like) {
+    public static ChallengeResponseDTO.ChallengeDTO toChallengeDTO(Challenge challenge, Integer dDay, String hostName, boolean like, Optional<Float> achieveRate) {
 
         List<String> challengeNotes = toStringChallengeNotes(challenge.getChallengeNotes());
 
-        return ChallengeResponseDTO.ChallengeDTO.builder()
+        ChallengeResponseDTO.ChallengeDTO.ChallengeDTOBuilder builder = ChallengeResponseDTO.ChallengeDTO.builder()
                 .attendeeCount(challenge.getAttendeeCount())
                 .hostName(hostName)
                 .createdDate(challenge.getCreatedAt().toLocalDate())
@@ -56,9 +57,16 @@ public class ChallengeConverter {
                 .likes(challenge.getCountLikes())
                 .like(like)
                 .period(challenge.getPeriod())
-                .totalGoalDay(challenge.getTotalGoalDay())
-                .build();
+                .totalGoalDay(challenge.getTotalGoalDay());
+
+        achieveRate.ifPresent(rate -> {
+            float roundedRate = Math.round(rate * 100) / 100.0f;
+            builder.achieveRate(roundedRate);
+        });
+
+        return builder.build();
     }
+
 
     public static List<String> toStringChallengeNotes(List<ChallengeNote> challengeNotes) {
 
@@ -111,7 +119,7 @@ public class ChallengeConverter {
                 .challengeId(challenge.getId())
                 .title(challenge.getTitle())
                 .imageUrl(challenge.getMainImageUrl())
-                .achieveRate(Math.round(achieveRate * 10) / 10.0f) // 소수점 아래 한자리까지만 보이도록
+                .achieveRate(Math.round(achieveRate * 100) / 100.0f) // 소수점 아래 한자리까지만 보이도록
                 .build();
     }
 }

--- a/src/main/java/com/BeilsangServer/domain/challenge/dto/ChallengeResponseDTO.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/dto/ChallengeResponseDTO.java
@@ -32,15 +32,13 @@ public class ChallengeResponseDTO {
         private Category category;
         private String details;
         private Integer joinPoint;
-        private Integer dDay;
-        // 챌린지 유의사항
-        private List<String> challengeNotes;
-        // 찜 개수
-        private Integer likes;
-        // 찜 여부
+        private Integer dDay; // 챌린지 유의사항
+        private List<String> challengeNotes; // 찜 개수
+        private Integer likes; // 찜 여부
         private boolean like;
         private ChallengePeriod period;
         private Integer totalGoalDay;
+        private Float achieveRate;
     }
 
     @Builder

--- a/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/BeilsangServer/domain/challenge/service/ChallengeService.java
@@ -34,6 +34,7 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -123,7 +124,16 @@ public class ChallengeService {
         // 챌린지 호스트 이름 찾기
         String hostName = getHostName(challengeId);
 
-        return ChallengeConverter.toChallengeDTO(challenge, dDay, hostName, like);
+        Optional<Float> achieveRate = Optional.empty();
+        // 멤버가 챌린지에 참여 중인지 확인
+        Optional<ChallengeMember> challengeMember = challengeMemberRepository.findByMember_idAndChallenge_Id(memberId, challengeId);
+        if (challengeMember.isPresent()) {
+            int successDays = challengeMember.get().getSuccessDays();
+            // 참여 중이라면 달성률 계산
+            achieveRate = Optional.of((float) successDays / challenge.getTotalGoalDay() * 100);
+        }
+
+        return ChallengeConverter.toChallengeDTO(challenge, dDay, hostName, like, achieveRate);
     }
 
     /***


### PR DESCRIPTION
기존의 챌린지 상세조회 시 달성율을 알 수 없다는 것을 알게 되었습니다.
멤버가 챌린지에 참여 중인지 확인 후, 참여 중이라면 달성율을 계산하여 응답하도록 했습니다.